### PR TITLE
Bugfix/whitescreen

### DIFF
--- a/src/components/dashboard/claim/index.js
+++ b/src/components/dashboard/claim/index.js
@@ -129,7 +129,7 @@ const useGetRewardsForMember = (address, networkId, web3) => {
 
 function renderRewardAmount(data, loading)
 {
-    if(loading) {
+    if(loading || !data) {
         return '...'
     }
 

--- a/src/components/dashboard/deposit/index.js
+++ b/src/components/dashboard/deposit/index.js
@@ -132,6 +132,8 @@ export default function Deposit() {
 
         const { KNC_STAKING_ADDRESS, KNC_TOKEN_ADDRESS } = getTokenAddresses(chainId)
     
+        console.log(`Calling SendKncTokensToStakeContract`)
+
         const stakeContract = await new web3.eth.Contract(KNC_STAKING_ABI, KNC_STAKING_ADDRESS)
         const tokenContract = await new web3.eth.Contract(KNC_TOKEN_ABI, KNC_TOKEN_ADDRESS)
 
@@ -141,6 +143,7 @@ export default function Deposit() {
         const hasUserApproved = await UserHasApprovedTokenSpend(amount)
 
         if(!hasUserApproved) {
+            console.log(`SendKncTokensToStakeContract -> User has not approved KNC`)
             const infinity = '999999999999999999999999999999999999999999'; //TODO - Make this a set amount or infinity?
             await tokenContract.methods.approve(KNC_STAKING_ADDRESS, infinity).send({from: address}, async function(err, txHash) {
                 console.log(err)
@@ -178,6 +181,8 @@ export default function Deposit() {
     const UserHasApprovedTokenSpend = async(amount) => {
         const { address, chainId, web3 } = context
         const { KNC_STAKING_ADDRESS, KNC_TOKEN_ADDRESS } = getTokenAddresses(chainId)
+
+        console.log(`Calling UserHasApprovedTokenSpend`)
     
         if(web3 === null) {
             console.log(`no web3 object - cannot SendKncTokensToStakeContract`)

--- a/src/components/dashboard/deposit/index.js
+++ b/src/components/dashboard/deposit/index.js
@@ -219,7 +219,9 @@ export default function Deposit() {
           return balance
         })
 
-        setKncBalance(balance)
+        if(balance) {
+            setKncBalance(balance)
+        }
     }
 
     useEffect(() => {
@@ -287,7 +289,7 @@ export default function Deposit() {
                         maxInput === 0 ? "disabled" : ""
                     }
                     onChange={(e) => setDepositAmount(e.target.value)}
-                    value={depositAmount > 0 ? depositAmount : null}
+                    value={depositAmount > 0 ? depositAmount : 0}
                 />
                 <MaxInputButton onClick={() => setDepositAmount(maxInput)}>
                     MAX

--- a/src/components/dashboard/portfolio/index.js
+++ b/src/components/dashboard/portfolio/index.js
@@ -74,7 +74,7 @@ export default function Portfolio() {
                         {
                             context => {
                                 return(
-                                    context.assets[0] && context.assets[0].eth > 0
+                                    context.assets.length > 0 && context.assets[0] && context.assets[0].eth > 0
                                         ?
                                             (context.assets[0].eth % 1 !== 0) 
                                                 ? (context.assets[0].eth).toFixed(4)
@@ -94,7 +94,7 @@ export default function Portfolio() {
                         {
                             context => {
                                 return(
-                                    context.assets[0] && context.assets[0].knc > 0
+                                    context.assets.length > 0 && context.assets[0] && context.assets[0].knc > 0
                                         ?
                                             (context.assets[0].knc % 1 !== 0) 
                                                 ? (context.assets[0].knc).toFixed(4)

--- a/src/components/dashboard/withdraw/index.js
+++ b/src/components/dashboard/withdraw/index.js
@@ -243,14 +243,19 @@ export default function Withdraw() {
             return data
         })
 
-        setStakeDetails({
-            delegatedStake: stake.delegatedStake,
-            representative: stake.representative,
-            stake: stake.stake
-        })
+        if(stake) {
+            setStakeDetails({
+                delegatedStake: stake.delegatedStake,
+                representative: stake.representative,
+                stake: stake.stake
+            })
+        }
     }
 
     useEffect(() => {
+
+        console.log(`doing stuff`)
+        return 
 
         async function doStuff() {
             await GetUserStakeDetails()
@@ -318,7 +323,7 @@ export default function Withdraw() {
                         maxInput === 0 ? "disabled" : ""
                     }
                     onChange={(e) => setWithdrawAmount(e.target.value)}
-                    value={withdrawAmount > 0 ? withdrawAmount : null}
+                    value={withdrawAmount > 0 ? withdrawAmount : 0}
                 />
                 <MaxInputButton 
                     onClick={() => setWithdrawAmount(maxInput)}

--- a/src/config/web3/index.js
+++ b/src/config/web3/index.js
@@ -4,7 +4,7 @@ const CONTRACT_CONFIG = require('./contracts/config.json')
 
 const WEB3SETTINGS = {
     INFURA: {
-        ID: "02b145caa61b49998168f2b97d4ef323"
+        ID: "27e3068734924aa8801ac58cd8240715"
     },
     CONTRACTS: {
         CONTRACT_CONFIG

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -8,7 +8,8 @@ const providerOptions = {
     walletconnect: {
       package: WalletConnectProvider,
       options: {
-        infuraId: WEB3SETTINGS.INFURA.ID
+        infuraId: WEB3SETTINGS.INFURA.ID,
+        pollingInterval: 60000
       }
     }
 };

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -9,7 +9,7 @@ const providerOptions = {
       package: WalletConnectProvider,
       options: {
         infuraId: WEB3SETTINGS.INFURA.ID,
-        pollingInterval: 60000
+        pollingInterval: 900000000000000 //a long time, we don't need the block number that walletconnect fetches
       }
     }
 };


### PR DESCRIPTION
- Added sanity check before data usage
- Added some debug comments to help debug if anything further happens
- Added logic to handle state  when switching between accounts
- Changed Infura ID

I believe the whitescreen was being caused to WalletConnect users because the application was using my personal Infura ID which got rate limited and WalletConnectProvider was throwing unhandled HTTP 429 errors.

If Infura returns with a HTTP 429 (Too Many Requests/Rate Limit), should we:

- Put the entire app into an error state (ie: Try connecting with MetaMask, Infura node is rate limited)?
- Show the app, but data returned and communicated may glitch out?