### PR TITLE
Fixed formatting error

### DIFF
--- a/src/components/dashboard/activity/timeline/index.js
+++ b/src/components/dashboard/activity/timeline/index.js
@@ -142,14 +142,13 @@ export default function Timeline(props) {
                         }
                     }
 
-
                     return(
                         <Row key={activity.tx_hash}>
                             <Part>
                                 <Icon src={iconSrc} title={type} alt={type} />
                             </Part>
                             <Part>
-                                {description.replace("{amount}", formattedValue.toFixed(2))}
+                                {description.replace("{amount}", formattedValue)}
                             </Part>
                             <Part>
                                 <DateTimestamp>


### PR DESCRIPTION
Fixed whitescreen error if you did an action with over 999 KNC. Also reported as the ledger issue

The issue was I was trying to issue a `toFixed(2)` on an already formatted string but it would only error out if you had did any action with kyber staking (deposit or withdraw) for other 999 KNC. I suspect this was reported as a ledger integration error because people were delegating high amounts via ledger instead of from metamask