### PR TITLE
Bugfix/visuals

### DIFF
--- a/src/components/dashboard/delegatedamount/index.js
+++ b/src/components/dashboard/delegatedamount/index.js
@@ -173,7 +173,7 @@ export default function DelegatedAmount() {
             {RenderEpochEndCountdown(epoch, epoch_lifespan_seconds)}
             <EpochCampaignsContainer>
                 {
-                    campaigns.length && <RenderCampaignVotes campaigns={campaigns} />
+                    campaigns.length > 0 && <RenderCampaignVotes campaigns={campaigns} />
                 }
             </EpochCampaignsContainer>
         </Container>

--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -4,10 +4,6 @@ export const toFixedDecimals = (number, decimals) => {
 
     const formattedNumber = ((Number(number) + (1 / x)).toFixed(d)).slice(0, -1)
 
-    if(formattedNumber.slice(-1) === "0") {
-        return formattedNumber.split('.')[0]
-    }
-
     return formattedNumber
 }
 


### PR DESCRIPTION
* Added fix to not show "0" if start of a new epoch and campaigns haven't been published yet
* Adjusted logic to show decimal places on claim if it's low (user with 0.0007 was shown 0 unless hovered over (?))